### PR TITLE
Add the Table of Content section to all pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ asciidoctor:
     - source-highlighter=coderay
     - icons=font
     - hardbreaks!
+    - toc=auto
 
 asciidoc_ext: txt
 


### PR DESCRIPTION
This add a Table Of Content section to all pages. To improve the readabilty of the website, expecially the pages related to the documentation, by giving a quick overview of the content.

Example in these screenshots:
![lime_web_toc_1](https://user-images.githubusercontent.com/67337653/234080110-5176087e-985d-491f-9500-441a7a049806.png)
![lime_web_toc_2](https://user-images.githubusercontent.com/67337653/234080115-4cb39955-a799-408f-917d-77efc11bdf9d.png)
