### PR TITLE
Suggest wpad-mesh-openssl rather than wpad-mesh-wolfssl

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -145,7 +145,7 @@ Additionally and optionally, httpS for the web interface can be enabled selectin
 
 Finally, also the 802.11s mesh connections can be password protected, this will require a specific configuration and this package to be selected:
 
-- Network -> wpad-mesh-wolfssl
+- Network -> wpad-mesh-openssl
 
 and this to be **de**-selected:
 
@@ -153,7 +153,7 @@ and this to be **de**-selected:
 
 [IMPORTANT]
 =========================
-Due to a link:https://bugs.openwrt.org/index.php?do=details&task_id=3441[known bug], can happen that wpad-mesh-wolfssl gets automatically deselected. **Each time you use menuconfig, please check if wpad-mesh-wolfssl is still selected.**
+Due to a link:https://bugs.openwrt.org/index.php?do=details&task_id=3441[known bug], can happen that wpad-mesh-openssl gets automatically deselected. **Each time you use menuconfig, please check if wpad-mesh-openssl is still selected.**
 =========================
 
 [NOTE]

--- a/development.txt
+++ b/development.txt
@@ -140,7 +140,6 @@ Some more packages are recommended but not mandatory for a working LibreMesh net
 
 Additionally and optionally, httpS for the web interface can be enabled selecting (beware that the web interace will be shown as *not trusted*):
 
-- Libraries -> libustream-wolfssl
 - Utilities -> Encryption -> px5g-standalone
 
 Finally, also the 802.11s mesh connections can be password protected, this will require a specific configuration and this package to be selected:


### PR DESCRIPTION
As mentioned here https://github.com/libremesh/lime-packages/issues/837 and by voice by @lindnermarek, OpenSSL can deal better than WolfSSL with encryption on lossy wireless links.

Currently, we are suggesting px5g-standalone and libustream-wolfssl for HTTPS in the web interface and wpad-mesh-wolfssl for wireless mesh encryption. Should we change also the first two packages or they can cohexist with OpenSSL? @dangowrt opinions?